### PR TITLE
Feat#65 child info lookup

### DIFF
--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -1,6 +1,7 @@
 package ifive.idrop.controller;
 
 import ifive.idrop.annotation.Login;
+import ifive.idrop.dto.BaseResponse;
 import ifive.idrop.dto.PickUpInfoResponse;
 import ifive.idrop.dto.TodayPickUpResponse;
 import ifive.idrop.entity.*;
@@ -23,14 +24,10 @@ public class PickUpController {
     private final PickUpService pickUpService;
 
     @GetMapping("/parent/pickup/valid")
-    public List<PickUpInfoResponse> getValidPickUpInfos(@Login Users user) {
-        if (!(user instanceof Parent)) {
-            throw new CommonException(ErrorCode.INVALID_ROLE_OF_USER);
-        }
-        Parent parent = (Parent) user;
+    public BaseResponse<List<PickUpInfoResponse>> getValidPickUpInfos(@Login Parent parent) {
         List<PickUpInfo> pickUpInfos = pickUpService.getValidPickUpInfosByParentId(parent.getId());
 
-        return pickUpInfos.stream().map(pi -> {
+        return BaseResponse.of("Data Successfully Proceed",pickUpInfos.stream().map(pi -> {
             Child child = pi.getChild();
             PickUpSubscribe ps = pi.getPickUpSubscribe();
 
@@ -42,18 +39,14 @@ public class PickUpController {
                     .startDate(ps.getModifiedDate())
                     .endDate(ps.getExpiredDate())
                     .build();
-        }).collect(Collectors.toList());
+        }).collect(Collectors.toList()));
     }
 
     @GetMapping("/driver/pickup/today")
-    public List<TodayPickUpResponse> getTodayPickUpInfos(@Login Users user) {
-        if (!(user instanceof Driver)) {
-            throw new CommonException(ErrorCode.INVALID_ROLE_OF_USER);
-        }
-        Driver driver = (Driver) user;
+    public BaseResponse<List<TodayPickUpResponse>> getTodayPickUpInfos(@Login Driver driver) {
         List<PickUp> pickUps = pickUpService.getTodayPickUpsByDriverId(driver.getId());
 
-        return pickUps.stream()
+        return BaseResponse.of("Data Successfully Proceed",pickUps.stream()
                 .map(p -> {
                     Child child = p.getPickUpInfo().getChild();
                     PickUpLocation pickUpLocation = p.getPickUpInfo().getPickUpLocation();
@@ -65,7 +58,7 @@ public class PickUpController {
                             .reservedTime(p.getReservedTime())
                             .build();
                 })
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
     }
 
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -3,47 +3,44 @@ package ifive.idrop.controller;
 import ifive.idrop.annotation.Login;
 import ifive.idrop.dto.PickUpInfoResponse;
 import ifive.idrop.entity.*;
-import ifive.idrop.entity.enums.Role;
+import ifive.idrop.exception.CommonException;
+import ifive.idrop.exception.ErrorCode;
 import ifive.idrop.service.PickUpService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Repository;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
-@Repository
-@RequiredArgsConstructor
 @RestController
+@RequiredArgsConstructor
 public class PickUpController {
 
     private final PickUpService pickUpService;
 
-    @GetMapping("/pickup/valid")
+    @GetMapping("/parent/pickup/valid")
     public List<PickUpInfoResponse> getValidPickUpInfos(@Login Users user) {
-        Role role = user.getRole();
-        List<PickUpInfo> pickUpInfos = null;
-        List<PickUpInfoResponse> response = new ArrayList<>();
-        if (role == Role.PARENT) {
-            Parent parent = (Parent) user;
-            pickUpInfos = pickUpService.getValidPickUpInfosByParentId(parent.getId());
+        if (!(user instanceof Parent)) {
+            throw new CommonException(ErrorCode.INVALID_ROLE_OF_USER);
         }
-        for (PickUpInfo pi : pickUpInfos) {
+        Parent parent = (Parent) user;
+        List<PickUpInfo> pickUpInfos = pickUpService.getValidPickUpInfosByParentId(parent.getId());
+
+        return pickUpInfos.stream().map(pi -> {
             Child child = pi.getChild();
             PickUpSubscribe ps = pi.getPickUpSubscribe();
 
-            response.add(PickUpInfoResponse.builder()
+            return PickUpInfoResponse.builder()
                     .startAddress(pi.getPickUpLocation().getStartAddress())
                     .endAddress(pi.getPickUpLocation().getEndAddress())
                     .childImage(child.getImage())
                     .childName(child.getName())
                     .startDate(ps.getModifiedDate())
                     .endDate(ps.getExpiredDate())
-                    .build());
-        }
-        return response;
+                    .build();
+        }).collect(Collectors.toList());
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -53,7 +53,7 @@ public class PickUpController {
                     return TodayPickUpResponse.builder()
                             .startAddress(pickUpLocation.getStartAddress())
                             .endAddress(pickUpLocation.getEndAddress())
-                            .childImage(child.getName())
+                            .childName(child.getName())
                             .childImage(child.getImage())
                             .reservedTime(p.getReservedTime())
                             .build();

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -2,6 +2,7 @@ package ifive.idrop.controller;
 
 import ifive.idrop.annotation.Login;
 import ifive.idrop.dto.PickUpInfoResponse;
+import ifive.idrop.dto.TodayPickUpResponse;
 import ifive.idrop.entity.*;
 import ifive.idrop.exception.CommonException;
 import ifive.idrop.exception.ErrorCode;
@@ -43,4 +44,28 @@ public class PickUpController {
                     .build();
         }).collect(Collectors.toList());
     }
+
+    @GetMapping("/driver/pickup/today")
+    public List<TodayPickUpResponse> getTodayPickUpInfos(@Login Users user) {
+        if (!(user instanceof Driver)) {
+            throw new CommonException(ErrorCode.INVALID_ROLE_OF_USER);
+        }
+        Driver driver = (Driver) user;
+        List<PickUp> pickUps = pickUpService.getTodayPickUpsByDriverId(driver.getId());
+
+        return pickUps.stream()
+                .map(p -> {
+                    Child child = p.getPickUpInfo().getChild();
+                    PickUpLocation pickUpLocation = p.getPickUpInfo().getPickUpLocation();
+                    return TodayPickUpResponse.builder()
+                            .startAddress(pickUpLocation.getStartAddress())
+                            .endAddress(pickUpLocation.getEndAddress())
+                            .childImage(child.getName())
+                            .childImage(child.getImage())
+                            .reservedTime(p.getReservedTime())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -1,0 +1,49 @@
+package ifive.idrop.controller;
+
+import ifive.idrop.annotation.Login;
+import ifive.idrop.dto.PickUpInfoResponse;
+import ifive.idrop.entity.*;
+import ifive.idrop.entity.enums.Role;
+import ifive.idrop.service.PickUpService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+@RestController
+public class PickUpController {
+
+    private final PickUpService pickUpService;
+
+    @GetMapping("/pickup/valid")
+    public List<PickUpInfoResponse> getValidPickUpInfos(@Login Users user) {
+        Role role = user.getRole();
+        List<PickUpInfo> pickUpInfos = null;
+        List<PickUpInfoResponse> response = new ArrayList<>();
+        if (role == Role.PARENT) {
+            Parent parent = (Parent) user;
+            pickUpInfos = pickUpService.getValidPickUpInfosByParentId(parent.getId());
+        }
+        for (PickUpInfo pi : pickUpInfos) {
+            Child child = pi.getChild();
+            PickUpSubscribe ps = pi.getPickUpSubscribe();
+
+            response.add(PickUpInfoResponse.builder()
+                    .startAddress(pi.getPickUpLocation().getStartAddress())
+                    .endAddress(pi.getPickUpLocation().getEndAddress())
+                    .childImage(child.getImage())
+                    .childName(child.getName())
+                    .startDate(ps.getModifiedDate())
+                    .endDate(ps.getExpiredDate())
+                    .build());
+        }
+        return response;
+    }
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/dto/PickUpInfoResponse.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/dto/PickUpInfoResponse.java
@@ -1,0 +1,18 @@
+package ifive.idrop.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PickUpInfoResponse {
+    private String startAddress;
+    private String endAddress;
+    private String childImage;
+    private String childName;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/dto/TodayPickUpResponse.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/dto/TodayPickUpResponse.java
@@ -1,0 +1,2 @@
+package ifive.idrop.dto;public class TodayPickUpResponse {
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/dto/TodayPickUpResponse.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/dto/TodayPickUpResponse.java
@@ -1,2 +1,16 @@
-package ifive.idrop.dto;public class TodayPickUpResponse {
+package ifive.idrop.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TodayPickUpResponse {
+    private String startAddress;
+    private String endAddress;
+    private String childImage;
+    private String childName;
+    private LocalDateTime reservedTime;
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/Car.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/Car.java
@@ -1,7 +1,9 @@
 package ifive.idrop.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
+@Getter
 @Entity
 public class Car {
     @Id

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/Child.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/Child.java
@@ -2,12 +2,14 @@ package ifive.idrop.entity;
 
 import ifive.idrop.entity.enums.Gender;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 public class Child {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
@@ -3,6 +3,7 @@ package ifive.idrop.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -22,4 +23,11 @@ public class PickUp {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pickup_info_id")
     private PickUpInfo pickUpInfo;
+
+    public boolean isToday() {
+        if (reservedTime.toLocalDate().equals(LocalDate.now())) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/PickUpInfo.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/PickUpInfo.java
@@ -30,7 +30,6 @@ public class PickUpInfo {
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "pickUpInfo")
     private PickUpSubscribe pickUpSubscribe;
 
-    @OneToMany
-    @JoinColumn(name = "pickup_info")
+    @OneToMany(mappedBy = "pickUpInfo")
     private List<PickUp> pickUpList = new ArrayList<>();
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/PickUpInfo.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/PickUpInfo.java
@@ -1,11 +1,13 @@
 package ifive.idrop.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 public class PickUpInfo {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/PickUpLocation.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/PickUpLocation.java
@@ -1,8 +1,10 @@
 package ifive.idrop.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class PickUpLocation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/PickUpSubscribe.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/PickUpSubscribe.java
@@ -2,11 +2,13 @@ package ifive.idrop.entity;
 
 import ifive.idrop.entity.enums.PickUpStatus;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
 @Entity
 public class PickUpSubscribe {
     @Id

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
@@ -1,2 +1,19 @@
-package ifive.idrop.repository;public class DriverRepository {
+package ifive.idrop.repository;
+
+import ifive.idrop.entity.Driver;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class DriverRepository {
+    private final EntityManager em;
+
+    public Optional<Driver> findByDriverId(Long driverId) {
+        Driver driver = em.find(Driver.class, driverId);
+        return Optional.ofNullable(driver);
+    }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
@@ -1,0 +1,2 @@
+package ifive.idrop.repository;public class DriverRepository {
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/ParentRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/ParentRepository.java
@@ -1,0 +1,20 @@
+package ifive.idrop.repository;
+
+import ifive.idrop.entity.Parent;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ParentRepository {
+
+    private final EntityManager em;
+
+    public Optional<Parent> findByParentId(Long parentId) {
+        Parent parent = em.find(Parent.class, parentId);
+        return Optional.ofNullable(parent);
+    }
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
@@ -1,5 +1,6 @@
 package ifive.idrop.repository;
 
+import ifive.idrop.entity.PickUp;
 import ifive.idrop.entity.PickUpInfo;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
@@ -19,6 +20,15 @@ public class PickUpRepository {
                 "SELECT pi FROM PickUpInfo  pi " +
                         "WHERE pi.child.id = :childId ", PickUpInfo.class);
         query.setParameter("childId", childId);
+
+        return query.getResultList();
+    }
+
+    public List<PickUpInfo> findPickupInfosByDriverId(Long driverId) {
+        TypedQuery<PickUpInfo> query = em.createQuery(
+                "SELECT pi FROM PickUpInfo  pi " +
+                        "WHERE pi.driver.id = :driverId ", PickUpInfo.class);
+        query.setParameter("driverId", driverId);
 
         return query.getResultList();
     }

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
@@ -1,0 +1,25 @@
+package ifive.idrop.repository;
+
+import ifive.idrop.entity.PickUpInfo;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PickUpRepository {
+
+    private final EntityManager em;
+
+    public List<PickUpInfo> findPickupInfosByChildId(Long childId) {
+        TypedQuery<PickUpInfo> query = em.createQuery(
+                "SELECT pi FROM PickUpInfo  pi " +
+                        "WHERE pi.child.id = :childId ", PickUpInfo.class);
+        query.setParameter("childId", childId);
+
+        return query.getResultList();
+    }
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
@@ -1,0 +1,43 @@
+package ifive.idrop.service;
+
+import ifive.idrop.entity.Child;
+import ifive.idrop.entity.Parent;
+import ifive.idrop.entity.PickUpInfo;
+import ifive.idrop.exception.CommonException;
+import ifive.idrop.exception.ErrorCode;
+import ifive.idrop.repository.ParentRepository;
+import ifive.idrop.repository.PickUpRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PickUpService {
+
+    private final ParentRepository parentRepository;
+    private final PickUpRepository pickUpRepository;
+
+    public List<PickUpInfo> getValidPickUpInfosByParentId(Long parentId) {
+        List<PickUpInfo> response = new ArrayList<>();
+
+        Parent parent = parentRepository.findByParentId(parentId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        List<Child> childList = parent.getChildList();
+        for (Child child : childList) {
+            List<PickUpInfo> pickupInfosByChildId = pickUpRepository.findPickupInfosByChildId(child.getId());
+            for (PickUpInfo pi : pickupInfosByChildId) {
+                if (pi.getPickUpSubscribe().getExpiredDate().isAfter(LocalDateTime.now())) {
+                    response.add(pi);
+                }
+            }
+        }
+        return response;
+    }
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
@@ -1,9 +1,12 @@
 package ifive.idrop.service;
 
+import ifive.idrop.entity.Driver;
 import ifive.idrop.entity.Parent;
+import ifive.idrop.entity.PickUp;
 import ifive.idrop.entity.PickUpInfo;
 import ifive.idrop.exception.CommonException;
 import ifive.idrop.exception.ErrorCode;
+import ifive.idrop.repository.DriverRepository;
 import ifive.idrop.repository.ParentRepository;
 import ifive.idrop.repository.PickUpRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,7 @@ import java.util.stream.Collectors;
 public class PickUpService {
 
     private final ParentRepository parentRepository;
+    private final DriverRepository driverRepository;
     private final PickUpRepository pickUpRepository;
 
     public List<PickUpInfo> getValidPickUpInfosByParentId(Long parentId) {
@@ -33,4 +37,15 @@ public class PickUpService {
                 .filter(pi -> pi.getPickUpSubscribe().getExpiredDate().isAfter(now))
                 .collect(Collectors.toList());
     }
+
+    public List<PickUp> getTodayPickUpsByDriverId(Long driverId) {
+        Driver driver = driverRepository.findByDriverId(driverId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        return pickUpRepository.findPickupInfosByDriverId(driverId).stream()
+                .flatMap(pi -> pi.getPickUpList().stream())
+                .filter(PickUp::isToday)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/websocket/location/LocationWebSocketHandler.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/websocket/location/LocationWebSocketHandler.java
@@ -115,7 +115,6 @@ public class LocationWebSocketHandler extends TextWebSocketHandler {
     //웹소켓 세션에서 User 구하기
     private Users getUserBySession(WebSocketSession session) throws JsonProcessingException {
         // HTTP 헤더에서 엑세스 토큰을 꺼낸다.
-        System.out.println(session.getHandshakeHeaders().get("Sec-Websocket-Protocol"));
         String accessToken = String.valueOf(session.getHandshakeHeaders().get("Sec-Websocket-Protocol")).substring("Bearer ".length() + 1);
         AuthenticateUser authenticateUser = getAuthenticateUser(accessToken);
         return userRepository.findByUserId(authenticateUser.getUserId())

--- a/BE/iDrop/src/main/java/ifive/idrop/websocket/location/LocationWebSocketHandler.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/websocket/location/LocationWebSocketHandler.java
@@ -23,7 +23,6 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static ifive.idrop.entity.enums.Role.*;
@@ -54,6 +53,7 @@ public class LocationWebSocketHandler extends TextWebSocketHandler {
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         String sessionId = session.getId();
         sessions.put(sessionId, session);
+
 
         Users user = getUserBySession(session);
 
@@ -115,7 +115,8 @@ public class LocationWebSocketHandler extends TextWebSocketHandler {
     //웹소켓 세션에서 User 구하기
     private Users getUserBySession(WebSocketSession session) throws JsonProcessingException {
         // HTTP 헤더에서 엑세스 토큰을 꺼낸다.
-        String accessToken = String.valueOf(session.getHandshakeHeaders().get("authorization")).substring("Bearer ".length() + 1);
+        System.out.println(session.getHandshakeHeaders().get("Sec-Websocket-Protocol"));
+        String accessToken = String.valueOf(session.getHandshakeHeaders().get("Sec-Websocket-Protocol")).substring("Bearer ".length() + 1);
         AuthenticateUser authenticateUser = getAuthenticateUser(accessToken);
         return userRepository.findByUserId(authenticateUser.getUserId())
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));


### PR DESCRIPTION
## 요약
- (기사/부모) 각각의 메인 페이지에 필요한 아이 픽업 정보 api 구현

<br>

## 고민한 점
### 1. join or 자바 코드
정보를 하나 가져오기 위해 여러 테이블이 필요합니다.
두가지 방법을 생각했습니다.
#### - repository에서 Join을 여러번 해서 한번에 가져오기

한 번에 조회해서 가져오니 데이터베이스 접근 횟수 자체는 적어질 것 같습니다.
하지만 service 단계에서는 아무 비즈니스 로직이 없고 그저 repository를 호출하게 됩니다.
repository에서 만든 메서드는 재사용성이 매우 떨어집니다.

#### - repository에서는 작은 단위로 가져오고 service에서 자바 코드로 정보 조회하기

조금 작은 단위로 repository 메서드를 작성하기 때문에 재사용성이 좋습니다.
service 단계에서 어떤 비즈니스 로직이 돌아가고 있는지 확인할 수 있습니다.
한 정보를 찾기 위해 계속 데이터베이스를 조회해서 성능에 문제가 있을지 살짝 걱정됩니다.
    
고민하다가 2번 방식으로 코드를 작성하려고 노력해보았습니다.
팀원들의 의견도 궁금해서 많은 의견 남겨주시면 감사할 것 같습니다.

### 2. dto 사용 범위
dto를 controller에서만 사용하려다 보니 아래와 같이 .get 이 반복되는데 괜찮은 방식인지 의견이 궁금합니다.
```java
.startAddress(pi.getPickUpLocation().getStartAddress())
.endAddress(pi.getPickUpLocation().getEndAddress())
```

<br>

## 코드 흐름 간단 설명
- repository : driverId, childId에 따라 해당하는 픽업을 전부 조회합니다.
- service : repository에서 조회한 픽업 중 조건에 맞는 픽업을 골라냅니다.
- controller : 골라낸 픽업을 dto 모양에 맞춰 정리해서 응답합니다.

