### PR TITLE
Feat#98 separate bottom sheet components

### DIFF
--- a/FE/src/App.jsx
+++ b/FE/src/App.jsx
@@ -18,12 +18,13 @@ import DriverDetail, {
     loader as driverDetailLoader
 } from "./pages/DriverDetail/DriverDetail";
 import ParentSignUp from "./pages/SignUp/ParentSignUp";
-import { ParentMenu } from "./pages/Menu/Menu";
+import { DriverMenu, ParentMenu } from "./pages/Menu/Menu";
 
 const router = createBrowserRouter(
     createRoutesFromElements(
         <Route>
-            <Route path="/" element={<ParentMenu />} />
+            <Route path="/" element={<DriverMenu />} />
+            {/* <Route path="/" element={<ParentMenu />} /> */}
             <Route path="onboarding" element={<Onboarding />} />
             <Route path="/signup" element={<ParentSignUp />} />
             <Route path="login" element={<Login />} />

--- a/FE/src/components/Map/DriverMap.jsx
+++ b/FE/src/components/Map/DriverMap.jsx
@@ -12,7 +12,7 @@ import {
 } from "../../constants/constants";
 import { getCurrentLocation } from "../../utils/coords";
 import { getAccessToken } from "../../utils/auth";
-import { BottomSheet } from "../common/Bottomsheet/Bottomsheet";
+import { DriverBottomSheet } from "../common/Bottomsheet/Bottomsheet";
 import { useFetchGet } from "../../hooks/useFetch";
 
 export function DriverMap() {
@@ -27,13 +27,17 @@ export function DriverMap() {
 
     const center = !locationLoading && getLatLng(latitude, longitude);
     const map = useMap(mapElementRef, { center }, locationLoading);
-
-    const departureMarker = useMarker(map, center);
     const driverMarker = useMarker(map, center);
 
+    const departurePos = getLatLng(
+        exampleData.startLatitude,
+        exampleData.startLongitude
+    );
+    const departureMarker = useMarker(map, departurePos);
+
     const destinationPos = getLatLng(
-        exampleData[0].endLatitude,
-        exampleData[0].endLongitude
+        exampleData.endLatitude,
+        exampleData.endLongitude
     );
     const destinationMarker = useMarker(map, destinationPos);
 
@@ -111,26 +115,25 @@ export function DriverMap() {
         <div className={styles.wrapper}>
             {!map && <Loader />}
             <div ref={mapElementRef} id="map" className={styles.map} />
-            <BottomSheet
-                childData={exampleData}
-                userRole={userType.driver}
-            ></BottomSheet>
+            <DriverBottomSheet data={exampleData} />
         </div>
     );
 }
 
-const exampleData = [
-    {
-        childName: "김하나",
-        childImage: "String...",
-        startLatitude: 37.5138649,
-        startLongitude: 127.0295296,
-        startAddress: "에티버스러닝 학동캠퍼스",
-        endLatitude: 37.51559,
-        endLongitude: 127.0316161,
-        endAddress: "코마츠"
-    }
-];
+const exampleData = {
+    childName: "김하나",
+    childImage: "String...",
+    startAddress: "에티버스러닝 학동캠퍼스",
+    endAddress: "코마츠",
+    startDate: "2024.02.01",
+    endDate: "2024.02.29",
+    startTime: "09:00",
+    endTime: "10:00",
+    startLatitude: 37.5138649,
+    startLongitude: 127.0295296,
+    endLatitude: 37.51559,
+    endLongitude: 127.0316161
+};
 
 const query = "driver/pickup/now";
 const accessToken = getAccessToken();

--- a/FE/src/components/Map/ParentMap.jsx
+++ b/FE/src/components/Map/ParentMap.jsx
@@ -4,12 +4,8 @@ import { useCoords } from "../../hooks/useCoords";
 import { getLatLng } from "../../utils/map";
 import { useMap } from "../../hooks/useMap";
 import { Loader } from "../common/Loader/Loader";
-import { BottomSheet } from "../common/Bottomsheet/Bottomsheet";
-import {
-    PARENT_TOKEN,
-    WEBSOCKET_URL,
-    userType
-} from "../../constants/constants";
+import { ParentBottomSheet } from "../common/Bottomsheet/Bottomsheet";
+import { PARENT_TOKEN, WEBSOCKET_URL } from "../../constants/constants";
 import { useMarker } from "../../hooks/useMarker";
 import { useFetchGet } from "../../hooks/useFetch";
 import { getAccessToken } from "../../utils/auth";
@@ -27,7 +23,7 @@ export default function ParentMap() {
 
     const center =
         !locationLoading &&
-        getLatLng(exampleData[0].startLatitude, exampleData[0].startLongitude);
+        getLatLng(exampleData.startLatitude, exampleData.startLongitude);
 
     const map = useMap(mapElementRef, { center }, locationLoading);
 
@@ -35,8 +31,8 @@ export default function ParentMap() {
     const driverMarker = useMarker(map, center);
 
     const destinationPos = getLatLng(
-        exampleData[0].endLatitude,
-        exampleData[0].endLongitude
+        exampleData.endLatitude,
+        exampleData.endLongitude
     );
     const destinationMarker = useMarker(map, destinationPos);
 
@@ -71,14 +67,7 @@ export default function ParentMap() {
         <div className={styles.wrapper}>
             {!map && <Loader />}
             <div ref={mapElementRef} id="map" className={styles.map} />
-            {loading ? (
-                <Loader />
-            ) : (
-                <BottomSheet
-                    childData={exampleData}
-                    userRole={userType.parent}
-                />
-            )}
+            {loading ? <Loader /> : <ParentBottomSheet data={exampleData} />}
         </div>
     );
 }
@@ -89,25 +78,17 @@ const header = {
     Bearer: accessToken
 };
 
-const exampleData = [
-    {
-        childName: "김하나",
-        childImage: "String...",
-        startLatitude: 37.5138649,
-        startLongitude: 127.0295296,
-        startAddress: "에티버스러닝 학동캠퍼스",
-        endLatitude: 37.51559,
-        endLongitude: 127.0316161,
-        endAddress: "코마츠"
-    },
-    {
-        childName: "이하나",
-        childImage: "String...",
-        startLatitude: 37.5138649,
-        startLongitude: 127.0295296,
-        startAddress: "에티버스러닝 학동캠퍼스",
-        endLatitude: 37.51559,
-        endLongitude: 127.0316161,
-        endAddress: "코마츠"
-    }
-];
+const exampleData = {
+    childName: "김하나",
+    childImage: "String...",
+    startAddress: "에티버스러닝 학동캠퍼스",
+    endAddress: "코마츠",
+    startDate: "2024.02.01",
+    endDate: "2024.02.29",
+    startTime: "09:00",
+    endTime: "10:00",
+    startLatitude: 37.5138649,
+    startLongitude: 127.0295296,
+    endLatitude: 37.51559,
+    endLongitude: 127.0316161
+};

--- a/FE/src/components/common/Bottomsheet/Bottomsheet.jsx
+++ b/FE/src/components/common/Bottomsheet/Bottomsheet.jsx
@@ -1,29 +1,41 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import styles from "./bottomsheet.module.scss";
-import { KidInfoComponent } from "./kidInfoBox";
-import { userType } from "../../../constants/constants";
+import { DriverContents, KidInfoComponent, ParentContents } from "./kidInfoBox";
 import { Footer } from "../Footer/Footer";
 
-export function BottomSheet({ childData, userRole }) {
-    const msg =
-        userRole === userType.driver ? "오늘의 픽업" : "픽업 서비스 구독 중";
+export function ParentBottomSheet({ data }) {
+    return (
+        <BttmSheetTemplate>
+            <ParentContents {...data} />
+        </BttmSheetTemplate>
+    );
+}
 
-    const [isExpanded, setIsExpanded] = useState(false);
-
-    const toggleBottomSheet = () => {
-        setIsExpanded(!isExpanded);
-    };
+export function DriverBottomSheet({ data }) {
+    const { pathname } = useLocation();
 
     const navigate = useNavigate();
     const movePage = () => {
         navigate("/pickup", { state: { flag: true } });
     };
+    return (
+        <BttmSheetTemplate>
+            <DriverContents {...data}></DriverContents>
+            {pathname === "/map" ? (
+                <Footer text={"운행종료"} onClick={movePage} />
+            ) : (
+                ""
+            )}
+        </BttmSheetTemplate>
+    );
+}
 
-    const renderButton = () => {
-        if (userRole == userType.driver) {
-            return <Footer text={"운행 종료"} onClick={movePage} />;
-        }
+function BttmSheetTemplate({ children }) {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const toggleBottomSheet = () => {
+        setIsExpanded(!isExpanded);
     };
 
     return (
@@ -34,13 +46,7 @@ export function BottomSheet({ childData, userRole }) {
             <header>
                 <div className={styles.handle}></div>
             </header>
-            <h3>{msg}</h3>
-            <div className={styles.list}>
-                {childData.map((data, index) => (
-                    <KidInfoComponent {...data} key={index} />
-                ))}
-            </div>
-            {renderButton()}
+            {children}
         </div>
     );
 }

--- a/FE/src/components/common/Bottomsheet/Bottomsheet.module.scss
+++ b/FE/src/components/common/Bottomsheet/Bottomsheet.module.scss
@@ -25,6 +25,7 @@
 header {
     display: flex;
     height: 10%;
+    margin-bottom: 10px;
     cursor: pointer;
 }
 

--- a/FE/src/components/common/Bottomsheet/KidInfoBox.jsx
+++ b/FE/src/components/common/Bottomsheet/KidInfoBox.jsx
@@ -1,3 +1,4 @@
+import { useLocation } from "react-router-dom";
 import styles from "./kidInfoBox.module.scss";
 import iDrop from "@/assets/iDropGreen.svg";
 
@@ -22,5 +23,64 @@ export function KidInfoComponent({
                 </span>
             </div>
         </div>
+    );
+}
+
+export function DriverContents({
+    childName,
+    childImage,
+    startAddress,
+    endAddress,
+    startTime,
+    endTime
+}) {
+    return (
+        <>
+            <h3>오늘의 픽업</h3>
+            <div className={styles.content}>
+                <img className={styles.kidImg} src={childImage || iDrop}></img>
+                <div className={styles.infoBox}>
+                    <span>{childName}</span>
+                    <span>
+                        {startTime || "2024.02.01"} ~ {endTime || "2024.02.28"}
+                    </span>
+                    <span>
+                        {startAddress} {"→"} {endAddress}
+                    </span>
+                </div>
+            </div>
+        </>
+    );
+}
+
+export function ParentContents({
+    childName,
+    childImage,
+    startAddress,
+    endAddress,
+    startDate,
+    endDate,
+    startTime,
+    endTime
+}) {
+    const { pathname } = useLocation();
+    const MSG =
+        pathname === "/map"
+            ? `${startTime} ~ ${endTime}`
+            : `${startDate} ~ ${endDate}`;
+    return (
+        <>
+            <h3>픽업 쏴비수 구독 중</h3>
+            <div className={styles.content}>
+                <img className={styles.kidImg} src={childImage || iDrop}></img>
+                <div className={styles.infoBox}>
+                    <span>{childName}</span>
+                    <span>{MSG}</span>
+                    <span>
+                        {startAddress} {"→"} {endAddress}
+                    </span>
+                </div>
+            </div>
+        </>
     );
 }

--- a/FE/src/pages/Menu/Menu.jsx
+++ b/FE/src/pages/Menu/Menu.jsx
@@ -1,8 +1,10 @@
 import styles from "./Menu.module.scss";
 import { MenuButton } from "./menuButton";
 import iDropGreen from "@/assets/iDropGreen.svg";
-import { BottomSheet } from "../../components/common/Bottomsheet/Bottomsheet";
-import { MENU_PAGE } from "../../constants/constants";
+import {
+    DriverBottomSheet,
+    ParentBottomSheet
+} from "../../components/common/Bottomsheet/Bottomsheet";
 import Location from "@/assets/Location.svg";
 import Star from "@/assets/Star.svg";
 import Success from "@/assets/Success.svg";
@@ -26,7 +28,7 @@ export function DriverMenu() {
                 <span>{INTRO_TEXT}</span>
             </div>
             <div className={styles.menuContainer}>{renderMenuItems()}</div>
-            <BottomSheet childData={exampleData}></BottomSheet>
+            <DriverBottomSheet data={exampleData} />
         </div>
     );
 }
@@ -47,21 +49,21 @@ export function ParentMenu() {
                 <span>{INTRO_TEXT}</span>
             </div>
             <div className={styles.menuContainer}>{renderMenuItems()}</div>
-            <BottomSheet childData={exampleData}></BottomSheet>
+            <ParentBottomSheet data={exampleData}></ParentBottomSheet>
         </div>
     );
 }
 
-const exampleData = [
-    {
-        childName: "김하나",
-        childImage: "String...",
-        startAddress: "에티버스러닝 학동캠퍼스",
-        endAddress: "코마츠",
-        startDate: "2024.02.01",
-        endDate: "2024.02.29"
-    }
-];
+const exampleData = {
+    childName: "김하나",
+    childImage: "String...",
+    startAddress: "에티버스러닝 학동캠퍼스",
+    endAddress: "코마츠",
+    startDate: "2024.02.01",
+    endDate: "2024.02.29",
+    startTime: "09:00",
+    endTime: "10:00"
+};
 
 const DRIVER_MENU_PAGE = (userName) => ({
     HELLO_MSG: `안녕하세요, ${userName}님`,


### PR DESCRIPTION
바텀시트 컴포넌트 분리

**분리 이유**
- 기존 바텀시트에서 유저정보를 props로 받아 분기처리를 진행
- 분기처리해야할 경우의 수가 많아짐에 따라 분기로직 복잡도 상승
- 따라서 부모의 바텀시트와 기사의 바텀시트를 각각의 컴포넌트로 분리

**구현 내용**
- [x] 바텀시트 분리
    - 바텀시트 기본 템플릿
    - 내부 콘텐츠 분리 (부모, 기사에 따라 보여지는 내용이 다름)
- [x] 부모 바텀시트 구현
- [x] 기사 바텀시트 구현 