### PR TITLE
Feat#99 subscribe info

### DIFF
--- a/BE/iDrop/src/main/java/ifive/idrop/controller/CommonController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/CommonController.java
@@ -1,21 +1,28 @@
 package ifive.idrop.controller;
 
 import ifive.idrop.annotation.Login;
+import ifive.idrop.dto.response.BaseResponse;
+import ifive.idrop.dto.response.CurrentPickUpResponse;
 import ifive.idrop.dto.response.DriverDetailResponse;
 import ifive.idrop.entity.Driver;
+import ifive.idrop.entity.Parent;
 import ifive.idrop.entity.Users;
 import ifive.idrop.exception.CommonException;
 import ifive.idrop.exception.ErrorCode;
 import ifive.idrop.service.DriverService;
+import ifive.idrop.service.ParentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RestController
 public class CommonController {
     private final DriverService driverService;
+    private final ParentService parentService;
 
     @GetMapping("/detail/driver/{driverId}")
     public DriverDetailResponse detailDriver(@Login Users user, @PathVariable("driverId") Long driverId) {
@@ -25,5 +32,18 @@ public class CommonController {
             }
         }
         return driverService.detail(driverId);
+    }
+
+    @GetMapping("/user/pickup/now")
+    public BaseResponse checkPickUpInfo(@Login Users user) {
+        if (user instanceof Parent) {
+            return parentService.getChildRunningInfo((Parent) user);
+        }
+
+        if (user instanceof Driver) {
+            return driverService.getAllChildRunningInfo((Driver) user);
+        }
+
+        throw new CommonException(ErrorCode.UNAUTHORIZED_USER);
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
@@ -29,8 +29,12 @@ public class DriverController {
     }
 
     @GetMapping("/pickup/now")
+    public BaseResponse<List<CurrentPickUpResponse>> checkAllPickUpInfo(@Login Driver driver) {
+        return driverService.getAllChildRunningInfo(driver);
+    }
+
+    @GetMapping("/pickup/now/child")
     public BaseResponse<List<CurrentPickUpResponse>> checkPickUpInfo(@Login Driver driver) {
         return driverService.getChildRunningInfo(driver);
-
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
@@ -2,7 +2,7 @@ package ifive.idrop.controller;
 
 import ifive.idrop.annotation.Login;
 
-import ifive.idrop.dto.CurrentPickUpResponse;
+import ifive.idrop.dto.response.CurrentPickUpResponse;
 import ifive.idrop.dto.request.DriverInformation;
 import ifive.idrop.dto.response.BaseResponse;
 import ifive.idrop.entity.Driver;

--- a/BE/iDrop/src/main/java/ifive/idrop/dto/request/SubscribeRequest.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/dto/request/SubscribeRequest.java
@@ -6,7 +6,6 @@ import org.json.simple.JSONObject;
 @Getter
 public class SubscribeRequest {
     private Long driverId;
-    private String childName;
     private String startAddress;
     private Double startLongitude;
     private Double startLatitude;

--- a/BE/iDrop/src/main/java/ifive/idrop/dto/response/CurrentPickUpResponse.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/dto/response/CurrentPickUpResponse.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Getter
 public class CurrentPickUpResponse {
+    private Long childId;
     private String childName;
     private String childImage;
     private LocalDateTime startDate;
@@ -24,6 +25,7 @@ public class CurrentPickUpResponse {
 
     static public CurrentPickUpResponse of(PickUpInfo pickUpInfo, LocalDateTime reservedTime) {
         return CurrentPickUpResponse.builder()
+                .childId(pickUpInfo.getChild().getId())
                 .childName(pickUpInfo.getChild().getName())
                 .childImage(pickUpInfo.getChild().getImage())
                 .startDate(pickUpInfo.getPickUpSubscribe().getModifiedDate())

--- a/BE/iDrop/src/main/java/ifive/idrop/dto/response/CurrentPickUpResponse.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/dto/response/CurrentPickUpResponse.java
@@ -1,8 +1,11 @@
 package ifive.idrop.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import ifive.idrop.entity.PickUpInfo;
 import ifive.idrop.entity.PickUpLocation;
 import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Builder
 @AllArgsConstructor
@@ -10,14 +13,40 @@ import lombok.*;
 public class CurrentPickUpResponse {
     private String childName;
     private String childImage;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    @JsonUnwrapped
     private Destination destination;
 
-    static public CurrentPickUpResponse of(PickUpInfo pickUpInfo) {
+    @JsonUnwrapped
+    private TimeInfo timeInfo;
+
+    static public CurrentPickUpResponse of(PickUpInfo pickUpInfo, LocalDateTime reservedTime) {
         return CurrentPickUpResponse.builder()
                 .childName(pickUpInfo.getChild().getName())
                 .childImage(pickUpInfo.getChild().getImage())
+                .startDate(pickUpInfo.getPickUpSubscribe().getModifiedDate())
+                .endDate(pickUpInfo.getPickUpSubscribe().getExpiredDate())
+                .endDate(reservedTime.plusHours(1))
                 .destination(Destination.of(pickUpInfo.getPickUpLocation()))
+                .timeInfo(TimeInfo.of(reservedTime))
                 .build();
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    static class TimeInfo {
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+
+        static public TimeInfo of(LocalDateTime reservedTime) {
+            return TimeInfo.builder()
+                    .startTime(reservedTime)
+                    .endTime(reservedTime.plusHours(1))
+                    .build();
+        }
     }
 
     @Builder

--- a/BE/iDrop/src/main/java/ifive/idrop/dto/response/CurrentPickUpResponse.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/dto/response/CurrentPickUpResponse.java
@@ -1,4 +1,4 @@
-package ifive.idrop.dto;
+package ifive.idrop.dto.response;
 
 import ifive.idrop.entity.PickUpInfo;
 import ifive.idrop.entity.PickUpLocation;

--- a/BE/iDrop/src/main/java/ifive/idrop/dto/response/CurrentPickUpResponse.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/dto/response/CurrentPickUpResponse.java
@@ -30,7 +30,6 @@ public class CurrentPickUpResponse {
                 .childImage(pickUpInfo.getChild().getImage())
                 .startDate(pickUpInfo.getPickUpSubscribe().getModifiedDate())
                 .endDate(pickUpInfo.getPickUpSubscribe().getExpiredDate())
-                .endDate(reservedTime.plusHours(1))
                 .destination(Destination.of(pickUpInfo.getPickUpLocation()))
                 .timeInfo(TimeInfo.of(reservedTime))
                 .build();

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
@@ -69,7 +69,7 @@ public class DriverRepository {
                 "WHERE pui.driver.id =: driverId\n" +
                 "AND pu.startTime IS NOT NULL\n" +
                 "AND pu.endTime IS NULL\n" +
-                "AND pu.reservedTime >= CURRENT_TIMESTAMP";
+                "AND pu.reservedTime <= CURRENT_TIMESTAMP";
 
         return em.createQuery(query)
                 .setParameter("driverId", driverId)

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
@@ -9,6 +9,8 @@ import ifive.idrop.entity.PickUpInfo;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 
@@ -52,10 +54,11 @@ public class DriverRepository {
                 "FROM PickUpInfo pui\n" +
                 "JOIN PickUp pu ON pui.id = pu.pickUpInfo.id\n" +
                 "WHERE pui.driver.id =: driverId\n" +
-                "AND pu.startTime IS NOT NULL\n" +
+                "AND FUNCTION('DATE', pu.reservedTime) = :currentDate\n"+
                 "AND pu.endTime IS NULL";
         return em.createQuery(query)
                 .setParameter("driverId", driverId)
+                .setParameter("currentDate", LocalDate.now())
                 .getResultList();
     }
 

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
@@ -5,7 +5,6 @@ import ifive.idrop.entity.*;
 import ifive.idrop.util.RequestSchedule;
 import ifive.idrop.util.ScheduleUtils;
 import ifive.idrop.entity.Driver;
-import ifive.idrop.entity.PickUpInfo;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -47,14 +46,15 @@ public class DriverRepository {
         }
         return availableDrivers;
     }
-    public List<PickUpInfo> findRunningPickInfo(Long driverId) {
-        String query = "SELECT pui\n" +
+    public List<Object[]> findRunningPickInfo(Long driverId) {
+        String query = "SELECT pui, pu.reservedTime\n" +
                 "FROM PickUpInfo pui\n" +
                 "JOIN PickUp pu ON pui.id = pu.pickUpInfo.id\n" +
                 "WHERE pui.driver.id =: driverId\n" +
                 "AND pu.startTime IS NOT NULL\n" +
                 "AND pu.endTime IS NULL";
-        return em.createQuery(query, PickUpInfo.class)
+
+        return em.createQuery(query)
                 .setParameter("driverId", driverId)
                 .getResultList();
     }

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
@@ -48,7 +48,7 @@ public class DriverRepository {
         return availableDrivers;
     }
     public List<Object[]> findAllRunningPickInfo(Long driverId) {
-        String query = "SELECT pui\n" +
+        String query = "SELECT pui, pu.reservedTime\n" +
                 "FROM PickUpInfo pui\n" +
                 "JOIN PickUp pu ON pui.id = pu.pickUpInfo.id\n" +
                 "WHERE pui.driver.id =: driverId\n" +

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
@@ -5,6 +5,7 @@ import ifive.idrop.entity.*;
 import ifive.idrop.util.RequestSchedule;
 import ifive.idrop.util.ScheduleUtils;
 import ifive.idrop.entity.Driver;
+import ifive.idrop.entity.PickUpInfo;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -46,13 +47,26 @@ public class DriverRepository {
         }
         return availableDrivers;
     }
+    public List<Object[]> findAllRunningPickInfo(Long driverId) {
+        String query = "SELECT pui\n" +
+                "FROM PickUpInfo pui\n" +
+                "JOIN PickUp pu ON pui.id = pu.pickUpInfo.id\n" +
+                "WHERE pui.driver.id =: driverId\n" +
+                "AND pu.startTime IS NOT NULL\n" +
+                "AND pu.endTime IS NULL";
+        return em.createQuery(query)
+                .setParameter("driverId", driverId)
+                .getResultList();
+    }
+
     public List<Object[]> findRunningPickInfo(Long driverId) {
         String query = "SELECT pui, pu.reservedTime\n" +
                 "FROM PickUpInfo pui\n" +
                 "JOIN PickUp pu ON pui.id = pu.pickUpInfo.id\n" +
                 "WHERE pui.driver.id =: driverId\n" +
                 "AND pu.startTime IS NOT NULL\n" +
-                "AND pu.endTime IS NULL";
+                "AND pu.endTime IS NULL\n" +
+                "AND pu.reservedTime >= CURRENT_TIMESTAMP";
 
         return em.createQuery(query)
                 .setParameter("driverId", driverId)

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/ParentRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/ParentRepository.java
@@ -22,14 +22,14 @@ public class ParentRepository {
                 .findAny();
     }
 
-    public List<PickUpInfo> findRunningPickInfo(Long parentId) {
-        String query = "SELECT pui\n" +
+    public List<Object[]> findRunningPickInfo(Long parentId) {
+        String query = "SELECT pui, pu.reservedTime\n" +
                 "FROM PickUpInfo pui\n" +
                 "JOIN Child c ON pui.child.id = c.id\n" +
                 "JOIN PickUp pu ON pui.id = pu.pickUpInfo.id\n" +
                 "WHERE c.parent.id =: parentId AND pu.startTime IS NOT NULL\n" +
                 "AND pu.endTime IS NULL";
-        return em.createQuery(query, PickUpInfo.class)
+        return em.createQuery(query)
                 .setParameter("parentId", parentId)
                 .getResultList();
     }

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/ParentRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/ParentRepository.java
@@ -14,10 +14,9 @@ import java.util.Optional;
 public class ParentRepository {
     private final EntityManager em;
 
-    public Optional<Child> findChild(Long parentId, String childName) {
-        return em.createQuery("SELECT c FROM Child c where c.parent.id =: parentId AND c.name =: childName", Child.class)
+    public Optional<Child> findChild(Long parentId) {
+        return em.createQuery("SELECT c FROM Child c where c.parent.id =: parentId", Child.class)
                 .setParameter("parentId", parentId)
-                .setParameter("childName", childName)
                 .getResultList()
                 .stream()
                 .findAny();

--- a/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import ifive.idrop.dto.CurrentPickUpResponse;
+import ifive.idrop.dto.response.CurrentPickUpResponse;
 import ifive.idrop.entity.PickUpInfo;
 
 import java.util.List;

--- a/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import ifive.idrop.dto.response.CurrentPickUpResponse;
 import ifive.idrop.entity.PickUpInfo;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -44,12 +45,12 @@ public class DriverService {
         return driver.getDetail();
     }
 
+
     public BaseResponse<List<CurrentPickUpResponse>> getChildRunningInfo(Driver driver) {
-        List<PickUpInfo> runningPickInfo = driverRepository.findRunningPickInfo(driver.getId());
+        List<Object[]> runningPickInfo = driverRepository.findRunningPickInfo(driver.getId());
         return BaseResponse.of("Data Successfully Proceed",
                 runningPickInfo.stream()
-                        .map(CurrentPickUpResponse::of)
+                        .map(o -> CurrentPickUpResponse.of((PickUpInfo) o[0], (LocalDateTime) o[1]))
                         .toList());
     }
-
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
@@ -46,6 +46,14 @@ public class DriverService {
     }
 
 
+    public BaseResponse<List<CurrentPickUpResponse>> getAllChildRunningInfo(Driver driver) {
+        List<Object[]> runningPickInfo = driverRepository.findAllRunningPickInfo(driver.getId());
+        return BaseResponse.of("Data Successfully Proceed",
+                runningPickInfo.stream()
+                        .map(o -> CurrentPickUpResponse.of((PickUpInfo) o[0], (LocalDateTime) o[1]))
+                        .toList());
+    }
+
     public BaseResponse<List<CurrentPickUpResponse>> getChildRunningInfo(Driver driver) {
         List<Object[]> runningPickInfo = driverRepository.findRunningPickInfo(driver.getId());
         return BaseResponse.of("Data Successfully Proceed",

--- a/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
@@ -46,6 +46,7 @@ public class DriverService {
     }
 
 
+    @Transactional(readOnly = true)
     public BaseResponse<List<CurrentPickUpResponse>> getAllChildRunningInfo(Driver driver) {
         List<Object[]> runningPickInfo = driverRepository.findAllRunningPickInfo(driver.getId());
         return BaseResponse.of("Data Successfully Proceed",
@@ -54,6 +55,7 @@ public class DriverService {
                         .toList());
     }
 
+    @Transactional(readOnly = true)
     public BaseResponse<List<CurrentPickUpResponse>> getChildRunningInfo(Driver driver) {
         List<Object[]> runningPickInfo = driverRepository.findRunningPickInfo(driver.getId());
         return BaseResponse.of("Data Successfully Proceed",

--- a/BE/iDrop/src/main/java/ifive/idrop/service/ParentService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/ParentService.java
@@ -32,7 +32,7 @@ public class ParentService {
     public BaseResponse<String> createSubscribe(Parent parent, SubscribeRequest subscribeRequest) throws JSONException {
         Driver driver = driverRepository.findById(subscribeRequest.getDriverId())
                 .orElseThrow(() -> new CommonException(ErrorCode.DRIVER_NOT_EXIST));
-        Child child = parentRepository.findChild(parent.getId(), subscribeRequest.getChildName())
+        Child child = parentRepository.findChild(parent.getId())
                 .orElseThrow(() -> new CommonException(ErrorCode.CHILD_NOT_EXIST));
 
         PickUpSubscribe subscribe = createPickUpSubscribe();

--- a/BE/iDrop/src/main/java/ifive/idrop/service/ParentService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/ParentService.java
@@ -3,7 +3,7 @@ package ifive.idrop.service;
 
 import ifive.idrop.dto.response.BaseResponse;
 import ifive.idrop.dto.request.SubscribeRequest;
-import ifive.idrop.dto.CurrentPickUpResponse;
+import ifive.idrop.dto.response.CurrentPickUpResponse;
 
 import ifive.idrop.entity.*;
 import ifive.idrop.entity.enums.PickUpStatus;

--- a/BE/iDrop/src/main/java/ifive/idrop/service/ParentService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/ParentService.java
@@ -13,10 +13,10 @@ import ifive.idrop.repository.DriverRepository;
 import ifive.idrop.repository.ParentRepository;
 import ifive.idrop.repository.PickUpRepository;
 import ifive.idrop.util.Parser;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,7 +28,6 @@ public class ParentService {
     private final ParentRepository parentRepository;
     private final PickUpRepository pickUpRepository;
 
-    @Transactional
     public BaseResponse<String> createSubscribe(Parent parent, SubscribeRequest subscribeRequest) throws JSONException {
         Driver driver = driverRepository.findById(subscribeRequest.getDriverId())
                 .orElseThrow(() -> new CommonException(ErrorCode.DRIVER_NOT_EXIST));
@@ -48,11 +47,13 @@ public class ParentService {
 
         return BaseResponse.success();
     }
+
+    @Transactional(readOnly = true)
     public BaseResponse<List<CurrentPickUpResponse>> getChildRunningInfo(Parent parent) {
-        List<PickUpInfo> runningPickInfo = parentRepository.findRunningPickInfo(parent.getId());
+        List<Object[]> runningPickInfo = parentRepository.findRunningPickInfo(parent.getId());
         return BaseResponse.of("Data Successfully Proceed",
                 runningPickInfo.stream()
-                        .map(CurrentPickUpResponse::of)
+                        .map(o -> CurrentPickUpResponse.of((PickUpInfo) o[0], (LocalDateTime) o[1]))
                         .toList());
     }
 


### PR DESCRIPTION
## 구현내용

* 현재 픽업 정보중 부모의 응답 처리 내용을 변경하였습니다.
* 현재 픽업 정보중 기사의 응답 처리 내용을 변경하였습니다.
* 정책변경으로 인해 구독 요청 정보를 변경하였습니다.
    * 부모 아이 1대 1 매칭 변환으로 아이 이름은 요청하지 않도록 변경하였습니다.

---

원래의 Response에서 Json데이터를 내릴 때 Key 값이 한번 더 들어가게 하였는데, 프론트 개발자의 협의 결과 Key 값 없이 바로
데이터에 접근할 수 있도록 요청이 왔습니다.   
따라서 `@JsonUnwrapped`를 이용하여 Key값으로 감싸지 않고 값을 바로 보낼 수 있도록 하였습니다.