### PR TITLE
Feat#96 pickup start

### DIFF
--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -1,0 +1,41 @@
+package ifive.idrop.controller;
+
+import ifive.idrop.annotation.Login;
+import ifive.idrop.dto.response.BaseResponse;
+import ifive.idrop.entity.Driver;
+import ifive.idrop.entity.PickUp;
+import ifive.idrop.exception.CommonException;
+import ifive.idrop.exception.ErrorCode;
+import ifive.idrop.exception.ErrorResponse;
+import ifive.idrop.service.PickUpService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class PickUpController {
+
+    private final PickUpService pickUpService;
+
+    @PostMapping("/pickUp")
+    public BaseResponse<String> getStartPickUpInfoFromDriver(@Login Driver driver, Long pickUpId, @ModelAttribute MultipartFile image) {
+        PickUp pickUp = pickUpService.findByPickUpId(pickUpId);
+        if (!pickUp.isDriver(driver)) { //해당 기사의 픽업이 아님
+            throw new CommonException(ErrorCode.DRIVER_NOT_MATCHED);
+        }
+        try {
+            pickUpService.pickUpStart(pickUp.getId(), image);
+        } catch (IOException e) {
+            //TODO 에러 핸들링 고민
+        }
+        log.info("pickUp Start - driverId = {}, pickUpId = {}", driver.getId(), pickUp.getId());
+        return BaseResponse.success();
+    }
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -24,7 +24,7 @@ public class PickUpController {
     private final PickUpService pickUpService;
 
     @PostMapping("/pickup")
-    public BaseResponse<String> getStartPickUpInfoFromDriver(@Login Driver driver, Long childId, @ModelAttribute MultipartFile image, String startMessage) {
+    public BaseResponse<String> startPickUp(@Login Driver driver, Long childId, @ModelAttribute MultipartFile image, String startMessage) {
         PickUp pickUp = pickUpService.findCurrentPickUp(driver.getId(), childId)
                 .orElseThrow(() -> new CommonException(ErrorCode.CURRENT_PICKUP_NOT_FOUND));
         try {

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -24,14 +24,14 @@ public class PickUpController {
 
     private final PickUpService pickUpService;
 
-    @PostMapping("/pickUp")
-    public BaseResponse<String> getStartPickUpInfoFromDriver(@Login Driver driver, Long pickUpId, @ModelAttribute MultipartFile image) {
+    @PostMapping("/pickup")
+    public BaseResponse<String> getStartPickUpInfoFromDriver(@Login Driver driver, Long pickUpId, @ModelAttribute MultipartFile image, String startMessage) {
         PickUp pickUp = pickUpService.findByPickUpId(pickUpId);
         if (!pickUp.isDriver(driver)) { //해당 기사의 픽업이 아님
             throw new CommonException(ErrorCode.DRIVER_NOT_MATCHED);
         }
         try {
-            pickUpService.pickUpStart(pickUp.getId(), image);
+            pickUpService.pickUpStart(pickUp.getId(), image, startMessage);
         } catch (IOException e) {
             //TODO 에러 핸들링 고민
         }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -6,7 +6,6 @@ import ifive.idrop.entity.Driver;
 import ifive.idrop.entity.PickUp;
 import ifive.idrop.exception.CommonException;
 import ifive.idrop.exception.ErrorCode;
-import ifive.idrop.exception.ErrorResponse;
 import ifive.idrop.service.PickUpService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,15 +24,13 @@ public class PickUpController {
     private final PickUpService pickUpService;
 
     @PostMapping("/pickup")
-    public BaseResponse<String> getStartPickUpInfoFromDriver(@Login Driver driver, Long pickUpId, @ModelAttribute MultipartFile image, String startMessage) {
-        PickUp pickUp = pickUpService.findByPickUpId(pickUpId);
-        if (!pickUp.isDriver(driver)) { //해당 기사의 픽업이 아님
-            throw new CommonException(ErrorCode.DRIVER_NOT_MATCHED);
-        }
+    public BaseResponse<String> getStartPickUpInfoFromDriver(@Login Driver driver, Long childId, @ModelAttribute MultipartFile image, String startMessage) {
+        PickUp pickUp = pickUpService.findCurrentPickUp(driver.getId(), childId)
+                .orElseThrow(() -> new CommonException(ErrorCode.CURRENT_PICKUP_NOT_FOUND));
         try {
             pickUpService.pickUpStart(pickUp.getId(), image, startMessage);
         } catch (IOException e) {
-            //TODO 에러 핸들링 고민
+            new CommonException(ErrorCode.IMAGE_UPLOAD_ERROR);
         }
         log.info("pickUp Start - driverId = {}, pickUpId = {}", driver.getId(), pickUp.getId());
         return BaseResponse.success();

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
@@ -44,4 +44,8 @@ public class PickUp {
     public boolean isDriver(Driver driver) {
         return pickUpInfo.getDriver().getId().equals(driver.getId());
     }
+
+    public Child getChild() {
+        return pickUpInfo.getChild();
+    }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
@@ -23,7 +23,8 @@ public class PickUp {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private LocalDateTime reservedTime;
-    private String message;
+    private String startMessage;
+    private String endMessage;
 
     @ManyToOne
     @JoinColumn(name = "pickup_info_id")
@@ -34,9 +35,10 @@ public class PickUp {
         pickUpInfo.getPickUpList().add(this);
     }
 
-    public void updateStartPickUpInfo(String startImage, LocalDateTime startTime) {
+    public void updateStartPickUpInfo(String startImage, LocalDateTime startTime, String startMessage) {
         this.startImage = startImage;
         this.startTime = startTime;
+        this.startMessage = startMessage;
     }
 
     public boolean isDriver(Driver driver) {

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
@@ -2,9 +2,11 @@ package ifive.idrop.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Entity
 @Builder
 @RequiredArgsConstructor
@@ -30,5 +32,14 @@ public class PickUp {
     public void updatePickUpInfo(PickUpInfo pickUpInfo) {
         this.pickUpInfo = pickUpInfo;
         pickUpInfo.getPickUpList().add(this);
+    }
+
+    public void updateStartPickUpInfo(String startImage, LocalDateTime startTime) {
+        this.startImage = startImage;
+        this.startTime = startTime;
+    }
+
+    public boolean isDriver(Driver driver) {
+        return pickUpInfo.getDriver().getId().equals(driver.getId());
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/entity/PickUp.java
@@ -21,6 +21,7 @@ public class PickUp {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private LocalDateTime reservedTime;
+    private String message;
 
     @ManyToOne
     @JoinColumn(name = "pickup_info_id")

--- a/BE/iDrop/src/main/java/ifive/idrop/exception/ErrorCode.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/exception/ErrorCode.java
@@ -20,8 +20,9 @@ public enum ErrorCode {
     PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 맞지 않습니다.", "비밀번호를 다시 확인해주세요."),
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "성별이 정확하지 않습니다.", "성별은 '남성' 또는 '여성' 중 하나여야 합니다."),
     INVALID_DAY_OF_WEEK(HttpStatus.BAD_REQUEST, "요일이 정확하지 않습니다.", "요일은 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun' 중 하나입니다."),
-    PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "현재 업무 시간인 픽업이 없습니다.", "업무 시간에 위치추적을 시작해주세요");
-
+    CURRENT_PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "현재 업무 시간인 픽업이 없습니다.", "업무 시간에 위치추적을 시작해주세요"),
+    PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "픽업이 없습니다.", "픽업 id를 다시 확인해주세요")
+    ;
     private final HttpStatus httpStatus;
     private final String message;
     private final String solution;

--- a/BE/iDrop/src/main/java/ifive/idrop/exception/ErrorCode.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/exception/ErrorCode.java
@@ -20,10 +20,10 @@ public enum ErrorCode {
     PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 맞지 않습니다.", "비밀번호를 다시 확인해주세요."),
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "성별이 정확하지 않습니다.", "성별은 '남성' 또는 '여성' 중 하나여야 합니다."),
     INVALID_DAY_OF_WEEK(HttpStatus.BAD_REQUEST, "요일이 정확하지 않습니다.", "요일은 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun' 중 하나입니다."),
-    CURRENT_PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "현재 업무 시간인 픽업이 없습니다.", "업무 시간에 위치추적을 시작해주세요"),
-    PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "픽업이 없습니다.", "픽업 id를 다시 확인해주세요"),
-    DRIVER_NOT_MATCHED(HttpStatus.BAD_REQUEST, "해당 기사의 픽업이 아닙니다.", "해당 기사의 픽업인지 확인해주세요."),
-    PICKUP_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 시작된 픽업입니다.", "픽업 id를 다시 확인해주세요."),
+    CURRENT_PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "현재 업무 시간인 픽업이 없습니다.", "업무 시간에 픽업을 시작해주세요"),
+    PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "픽업이 없습니다.", "다시 확인해주세요"),
+    PICKUP_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 시작된 픽업입니다.", "다시 확인해주세요."),
+    IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 문제가 발생했습니다.", "다시 요청해주세요."),
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/BE/iDrop/src/main/java/ifive/idrop/exception/ErrorCode.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/exception/ErrorCode.java
@@ -21,7 +21,9 @@ public enum ErrorCode {
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "성별이 정확하지 않습니다.", "성별은 '남성' 또는 '여성' 중 하나여야 합니다."),
     INVALID_DAY_OF_WEEK(HttpStatus.BAD_REQUEST, "요일이 정확하지 않습니다.", "요일은 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun' 중 하나입니다."),
     CURRENT_PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "현재 업무 시간인 픽업이 없습니다.", "업무 시간에 위치추적을 시작해주세요"),
-    PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "픽업이 없습니다.", "픽업 id를 다시 확인해주세요")
+    PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "픽업이 없습니다.", "픽업 id를 다시 확인해주세요"),
+    DRIVER_NOT_MATCHED(HttpStatus.BAD_REQUEST, "해당 기사의 픽업이 아닙니다.", "해당 기사의 픽업인지 확인해주세요."),
+    PICKUP_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 시작된 픽업입니다.", "픽업 id를 다시 확인해주세요."),
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
@@ -60,4 +60,23 @@ public class PickUpRepository {
         pickUp.updateStartPickUpInfo(startImage, startTime, startMessage);
         em.merge(pickUp);
     }
+
+    /**
+     * driverId로 현재 해당 기사의 업무 시간에 해당하는 PickUp들 찾기
+     * @param driverId
+     * @return List<PickUp>
+     */
+    public List<PickUp> findPickUpsByDriverIdWithCurrentTimeInReservedWindow(Long driverId) {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 현재 시간이 reservedTime ~ reservedTime+1시간에 해당하는 PickUp들 찾기
+        String jpql = "SELECT p FROM PickUp p WHERE p.pickUpInfo.driver.id = :driverId " +
+                "AND (p.reservedTime - 10 MINUTE) <= :now AND :now <= (p.reservedTime + 1 HOUR)";
+
+        TypedQuery<PickUp> query = em.createQuery(jpql, PickUp.class);
+        query.setParameter("driverId", driverId);
+        query.setParameter("now", now);
+
+        return query.getResultList();
+    }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
@@ -53,11 +53,11 @@ public class PickUpRepository {
         return Optional.ofNullable(em.find(PickUp.class, pickUpId));
     }
 
-    public void savePickUpStartInfo(Long pickupId, String startImage, LocalDateTime startTime) {
+    public void savePickUpStartInfo(Long pickupId, String startImage, LocalDateTime startTime, String startMessage) {
         PickUp pickUp = Optional.ofNullable(em.find(PickUp.class, pickupId))
                 .orElseThrow(() -> new CommonException(ErrorCode.PICKUP_NOT_FOUND));
 
-        pickUp.updateStartPickUpInfo(startImage, startTime);
+        pickUp.updateStartPickUpInfo(startImage, startTime, startMessage);
         em.merge(pickUp);
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
@@ -2,11 +2,14 @@ package ifive.idrop.repository;
 
 import ifive.idrop.entity.*;
 import ifive.idrop.entity.enums.PickUpStatus;
+import ifive.idrop.exception.CommonException;
+import ifive.idrop.exception.ErrorCode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,5 +51,13 @@ public class PickUpRepository {
 
     public Optional<PickUp> findById(Long pickUpId) {
         return Optional.ofNullable(em.find(PickUp.class, pickUpId));
+    }
+
+    public void savePickUpStartInfo(Long pickupId, String startImage, LocalDateTime startTime) {
+        PickUp pickUp = Optional.ofNullable(em.find(PickUp.class, pickupId))
+                .orElseThrow(() -> new CommonException(ErrorCode.PICKUP_NOT_FOUND));
+
+        pickUp.updateStartPickUpInfo(startImage, startTime);
+        em.merge(pickUp);
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/PickUpRepository.java
@@ -1,6 +1,6 @@
 package ifive.idrop.repository;
 
-import ifive.idrop.entity.PickUp;
+import ifive.idrop.entity.*;
 import ifive.idrop.entity.enums.PickUpStatus;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
@@ -8,9 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import ifive.idrop.entity.PickUpInfo;
-import ifive.idrop.entity.PickUpLocation;
-import ifive.idrop.entity.PickUpSubscribe;
+import java.util.Optional;
 
 
 @Repository
@@ -46,5 +44,9 @@ public class PickUpRepository {
 
     public void savePickUp(PickUp pick) {
         em.persist(pick);
+    }
+
+    public Optional<PickUp> findById(Long pickUpId) {
+        return Optional.ofNullable(em.find(PickUp.class, pickUpId));
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
@@ -1,0 +1,41 @@
+package ifive.idrop.service;
+
+import ifive.idrop.entity.PickUp;
+import ifive.idrop.exception.CommonException;
+import ifive.idrop.exception.ErrorCode;
+import ifive.idrop.repository.PickUpRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PickUpService {
+
+    private final ImageService imageService;
+    private final PickUpRepository pickUpRepository;
+
+    @Transactional
+    public void pickUpStart(Long pickUpId, MultipartFile image) throws IOException {
+        PickUp pickUp = pickUpRepository.findById(pickUpId)
+                .orElseThrow(() -> new CommonException(ErrorCode.PICKUP_NOT_FOUND));
+        if (pickUp.getStartImage() == null) {
+            String imageUrl = imageService.upload(image, "image/pickup/");
+            pickUpRepository.savePickUpStartInfo(pickUpId, imageUrl, LocalDateTime.now());
+        } else {
+            throw new CommonException(ErrorCode.PICKUP_ALREADY_STARTED);
+        }
+    }
+
+    public PickUp findByPickUpId(Long pickUpId) {
+        return pickUpRepository.findById(pickUpId)
+                .orElseThrow(() -> new CommonException(ErrorCode.PICKUP_NOT_FOUND));
+    }
+
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
@@ -12,6 +12,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -36,6 +38,14 @@ public class PickUpService {
     public PickUp findByPickUpId(Long pickUpId) {
         return pickUpRepository.findById(pickUpId)
                 .orElseThrow(() -> new CommonException(ErrorCode.PICKUP_NOT_FOUND));
+    }
+
+    public Optional<PickUp> findCurrentPickUp(Long driverId, Long childId) {
+        List<PickUp> pickUps = pickUpRepository.findPickUpsByDriverIdWithCurrentTimeInReservedWindow(driverId);
+        Optional<PickUp> result = pickUps.stream()
+                .filter(p -> p.getChild().getId().equals(childId))
+                .findFirst();
+        return result;
     }
 
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/PickUpService.java
@@ -22,12 +22,12 @@ public class PickUpService {
     private final PickUpRepository pickUpRepository;
 
     @Transactional
-    public void pickUpStart(Long pickUpId, MultipartFile image) throws IOException {
+    public void pickUpStart(Long pickUpId, MultipartFile image, String startMessage) throws IOException {
         PickUp pickUp = pickUpRepository.findById(pickUpId)
                 .orElseThrow(() -> new CommonException(ErrorCode.PICKUP_NOT_FOUND));
         if (pickUp.getStartImage() == null) {
             String imageUrl = imageService.upload(image, "image/pickup/");
-            pickUpRepository.savePickUpStartInfo(pickUpId, imageUrl, LocalDateTime.now());
+            pickUpRepository.savePickUpStartInfo(pickUpId, imageUrl, LocalDateTime.now(), startMessage);
         } else {
             throw new CommonException(ErrorCode.PICKUP_ALREADY_STARTED);
         }


### PR DESCRIPTION
## 구현 내용
### - POST /pickup
픽업이 시작되었을 때, 기사가 보낸 정보들을 pickUp 테이블에 저장합니다.
(예약시간-10분) <= 현재 <= (예약시간+1시간) 인 픽업들 중, driverId와 childId가 같은 픽업을 조회합니다.

```json
{
	"childId": Long,
	"image": multipartFile,
	"message": String
}
```

이미지는 아래와 같이 받으면 됩니다.
```java
@ModelAttribute MultipartFile image
```


## 에러 처리
### PICKUP_ALREADY_STARTED
```json
{
    "message": "이미 시작된 픽업입니다.",
    "solution": "다시 확인해주세요."
}
```
```java
@Transactional
    public void pickUpStart(Long pickUpId, MultipartFile image, String startMessage) throws IOException {
        PickUp pickUp = pickUpRepository.findById(pickUpId)
                .orElseThrow(() -> new CommonException(ErrorCode.PICKUP_NOT_FOUND));
        if (pickUp.getStartImage() == null) {
            String imageUrl = imageService.upload(image, "image/pickup/");
            pickUpRepository.savePickUpStartInfo(pickUpId, imageUrl, LocalDateTime.now(), startMessage);
        } else {
            throw new CommonException(ErrorCode.PICKUP_ALREADY_STARTED);
        }
    }
```
`pickUp.getStartImage()`가 null이 아닐 시, 이미 시작된 픽업입니다.

### PICKUP_NOT_FOUND
```json
{
    "message": "현재 업무 시간인 픽업이 없습니다.",
    "solution": "업무 시간에 픽업을 시작해주세요"
}
```
현재 업무 시간인 픽업이 없을 시 다음 에러를 반환합니다.