### PR TITLE
fix: OPTIONS 메소드 preflight 허용

### DIFF
--- a/BE/iDrop/src/main/java/ifive/idrop/filter/JwtAuthorizationFilter.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/filter/JwtAuthorizationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthorizationFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
         HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-        if (whiteListCheck(httpServletRequest.getRequestURI())){
+        if (whiteListCheck(httpServletRequest.getRequestURI()) || httpServletRequest.getMethod().equals("OPTIONS")){
             chain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
요청을 보내기 전에 preflight 요청을 보낼때 Authorization 헤더가 없어 필더에서 걸리던 것을 수정하여 Http Method가 OPTIONS라면 토큰을 검사하지 않도록 하였습니다.