### PR TITLE
feat: 실시간 위치 반영해서 경로 찾기

### DIFF
--- a/BE/iDrop/.gitignore
+++ b/BE/iDrop/.gitignore
@@ -39,3 +39,4 @@ out/
 /src/main/resources/*.sql
 
 .DS_Store
+.jmx

--- a/BE/iDrop/src/main/java/ifive/idrop/websocket/direction/NaverDirectionFinder.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/websocket/direction/NaverDirectionFinder.java
@@ -1,6 +1,7 @@
 package ifive.idrop.websocket.direction;
 
 import ifive.idrop.entity.PickUpLocation;
+import ifive.idrop.websocket.location.DriverGeoLocation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,5 +51,9 @@ public class NaverDirectionFinder {
 
     public String getEndLocationForApi(PickUpLocation pickUpLocation) {
         return pickUpLocation.getEndLongitude() + "," + pickUpLocation.getEndLatitude();
+    }
+
+    public String getLocationForApi(DriverGeoLocation location) {
+        return location.getLongitude() + "," + location.getLatitude();
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/websocket/location/DriverGeoLocation.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/websocket/location/DriverGeoLocation.java
@@ -13,4 +13,12 @@ public class DriverGeoLocation {
     private Double longitude;
     private Double latitude;
     private LocalDateTime createdAt;
+
+    public boolean isSameLocation(Location location) {
+        return this.longitude.equals(location.getLongitude()) && this.latitude.equals(location.getLatitude());
+    }
+
+    public Location getLocation() {
+        return new Location(longitude, latitude);
+    }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/websocket/location/Location.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/websocket/location/Location.java
@@ -1,0 +1,16 @@
+package ifive.idrop.websocket.location;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Location {
+    private Double longitude;
+    private Double latitude;
+
+    public void update(DriverGeoLocation driverGeoLocation) {
+        this.longitude = driverGeoLocation.getLongitude();
+        this.latitude = driverGeoLocation.getLatitude();
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 실시간으로 경로 다시 조회하여 기사에게 보내줌
- 전에 기사가 보냈던 위치 기록, 전에 보냈던 위치와 다를 때만 네이버 경로찾기 api 호출하여 경로 재조회
- 부모에게는 추후 개발예정

### LocationWebSocketHandler
전의 위치 기록이 없으면 소켓에 새로 접속한 기사이므로 위치를 map에 넣어준다.
전의 위치 기록이 있고, 전의 위치와 현재 위치가 다르면 네이버 경로찾기 api를 호출하여 기사에게 보내준다.
```java
Location location = lastLocation.get(sessionId);
if (location == null) { //전 위치 기록이 없음 첫 위치
    lastLocation.put(sessionId, driverLocation.getLocation());
}
else {
    if (!driverLocation.isSameLocation(location)) { //전에 왔던 위치와 다른 위치
        String loc = directionFinder.getLocationForApi(driverLocation);
        Direction direction = directionFinder.getDirection(loc, currentPickUp.getEndLocation());
        session.sendMessage(new TextMessage(CustomObjectMapper.getString(direction)));
        location.update(driverLocation);
        lastLocation.replace(sessionId, location);
    }
}
```