### PR TITLE
Feat#147 driver today rest of pickup

### DIFF
--- a/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
@@ -53,7 +53,7 @@ public class DriverController {
     @GetMapping("/pickup/today/remaining")
     public BaseResponse<List<DriverTodayRemainingPickUpResponse>> getRemainingPickUpList(@Login Driver driver) {
         List<DriverTodayRemainingPickUpResponse> pickUpList = driverService.getTodayRemainingPickUpList(driver.getId());
-        if(pickUpList.size()==0)
+        if(pickUpList.isEmpty())
             throw new CommonException(ErrorCode.PICKUP_NOT_FOUND);
         return BaseResponse.of("Data Successfully Proceed", pickUpList);
     }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
@@ -6,6 +6,8 @@ import ifive.idrop.dto.request.SubscribeCheckRequest;
 import ifive.idrop.dto.response.*;
 import ifive.idrop.dto.request.DriverInformation;
 import ifive.idrop.entity.Driver;
+import ifive.idrop.exception.CommonException;
+import ifive.idrop.exception.ErrorCode;
 import ifive.idrop.service.DriverService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,6 +52,9 @@ public class DriverController {
 
     @GetMapping("/pickup/today/remaining")
     public BaseResponse<List<DriverTodayRemainingPickUpResponse>> getRemainingPickUpList(@Login Driver driver) {
-        return BaseResponse.of("Data Successfully Proceed", driverService.getTodayRemainingPickUpList(driver.getId()));
+        List<DriverTodayRemainingPickUpResponse> pickUpList = driverService.getTodayRemainingPickUpList(driver.getId());
+        if(pickUpList.size()==0)
+            throw new CommonException(ErrorCode.PICKUP_NOT_FOUND);
+        return BaseResponse.of("Data Successfully Proceed", pickUpList);
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
@@ -3,11 +3,8 @@ package ifive.idrop.controller;
 import ifive.idrop.annotation.Login;
 
 import ifive.idrop.dto.request.SubscribeCheckRequest;
-import ifive.idrop.dto.response.CurrentPickUpResponse;
+import ifive.idrop.dto.response.*;
 import ifive.idrop.dto.request.DriverInformation;
-import ifive.idrop.dto.response.BaseResponse;
-import ifive.idrop.dto.response.DriverSubscribeInfoResponse;
-import ifive.idrop.dto.response.ParentSubscribeInfoResponse;
 import ifive.idrop.entity.Driver;
 import ifive.idrop.service.DriverService;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +49,7 @@ public class DriverController {
     }
 
     @GetMapping("/pickup/today/remaining")
-    public BaseResponse<List<CurrentPickUpResponse>> getRemainingPickUpList(@Login Driver driver) {
-        return driverService.getTodayRemainingPickUpList(driver.getId());
+    public BaseResponse<List<DriverTodayRemainingPickUpResponse>> getRemainingPickUpList(@Login Driver driver) {
+        return BaseResponse.of("Data Successfully Proceed", driverService.getTodayRemainingPickUpList(driver.getId()));
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
@@ -50,4 +50,9 @@ public class DriverController {
     public BaseResponse subscribeCheck(@Login Driver driver, @RequestBody SubscribeCheckRequest subscribeCheckRequest) {
         return driverService.subscribeCheck(driver.getId(), subscribeCheckRequest);
     }
+
+    @GetMapping("/pickup/today/remaining")
+    public BaseResponse<List<CurrentPickUpResponse>> getRemainingPickUpList(@Login Driver driver) {
+        return driverService.getTodayRemainingPickUpList(driver.getId());
+    }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/DriverController.java
@@ -53,8 +53,6 @@ public class DriverController {
     @GetMapping("/pickup/today/remaining")
     public BaseResponse<List<DriverTodayRemainingPickUpResponse>> getRemainingPickUpList(@Login Driver driver) {
         List<DriverTodayRemainingPickUpResponse> pickUpList = driverService.getTodayRemainingPickUpList(driver.getId());
-        if(pickUpList.isEmpty())
-            throw new CommonException(ErrorCode.PICKUP_NOT_FOUND);
         return BaseResponse.of("Data Successfully Proceed", pickUpList);
     }
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/controller/PickUpController.java
@@ -25,7 +25,7 @@ public class PickUpController {
     private final PickUpService pickUpService;
 
     @PostMapping("/driver/pickup")
-    public BaseResponse<String> startPickUp(@Login Driver driver, Long childId, @ModelAttribute MultipartFile image, String message) {
+    public BaseResponse<String> startOrEndPickUp(@Login Driver driver, Long childId, @ModelAttribute MultipartFile image, String message) {
         PickUp pickUp = pickUpService.findCurrentPickUp(driver.getId(), childId)
                 .orElseThrow(() -> new CommonException(ErrorCode.CURRENT_PICKUP_NOT_FOUND));
         try {

--- a/BE/iDrop/src/main/java/ifive/idrop/dto/response/DriverTodayRemainingPickUpResponse.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/dto/response/DriverTodayRemainingPickUpResponse.java
@@ -1,0 +1,74 @@
+package ifive.idrop.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import ifive.idrop.entity.PickUpInfo;
+import ifive.idrop.entity.PickUpLocation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class DriverTodayRemainingPickUpResponse {
+
+    private Long childId;
+    private String childName;
+    private String childImage;
+
+    @JsonUnwrapped
+    private Destination destination;
+
+    @JsonUnwrapped
+    private TimeInfo timeInfo;
+
+    static public DriverTodayRemainingPickUpResponse of(PickUpInfo pickUpInfo, LocalDateTime reservedTime) {
+        return DriverTodayRemainingPickUpResponse.builder()
+                .childId(pickUpInfo.getChild().getId())
+                .childName(pickUpInfo.getChild().getName())
+                .childImage(pickUpInfo.getChild().getImage())
+                .destination(DriverTodayRemainingPickUpResponse.Destination.of(pickUpInfo.getPickUpLocation()))
+                .timeInfo(DriverTodayRemainingPickUpResponse.TimeInfo.of(reservedTime))
+                .build();
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    static class TimeInfo {
+        private LocalDateTime pickUpStartTime;  // 실제 픽업 시작 시간
+        private LocalDateTime pickUpEndTime;    // 실제 픽업 마감 시간
+
+        static public DriverTodayRemainingPickUpResponse.TimeInfo of(LocalDateTime reservedTime) {
+            return DriverTodayRemainingPickUpResponse.TimeInfo.builder()
+                    .pickUpStartTime(reservedTime)
+                    .pickUpEndTime(reservedTime.plusHours(1))
+                    .build();
+        }
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    static class Destination {
+        private Double startLatitude;
+        private Double startLongitude;
+        private String startAddress;
+        private Double endLatitude;
+        private Double endLongitude;
+        private String endAddress;
+
+        static public DriverTodayRemainingPickUpResponse.Destination of(PickUpLocation location) {
+            return DriverTodayRemainingPickUpResponse.Destination.builder()
+                    .startAddress(location.getStartAddress())
+                    .startLatitude(location.getStartLatitude())
+                    .startLongitude(location.getStartLongitude())
+                    .endAddress(location.getEndAddress())
+                    .endLatitude(location.getEndLatitude())
+                    .endLongitude(location.getEndLongitude())
+                    .build();
+        }
+    }
+}

--- a/BE/iDrop/src/main/java/ifive/idrop/exception/ErrorCode.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
     INVALID_DAY_OF_WEEK(HttpStatus.BAD_REQUEST, "요일이 정확하지 않습니다.", "요일은 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun' 중 하나입니다."),
     INVALID_PICKUP_STATUS(HttpStatus.BAD_REQUEST, "픽업 상태가 정확하지 않습니다.", "상태는 '거절', '승인', '대기', '취소', '만료' 중 하나여야 합니다."),
     CURRENT_PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "현재 업무 시간인 픽업이 없습니다.", "업무 시간에 픽업을 시작해주세요"),
-    PICKUP_NOT_FOUND(HttpStatus.NOT_FOUND, "픽업이 없습니다.", "다시 확인해주세요"),
+    PICKUP_NOT_FOUND(HttpStatus.BAD_GATEWAY, "픽업이 없습니다.", "다시 확인해주세요"),
     PICKUP_INFO_NOT_EXIST(HttpStatus.BAD_REQUEST, "해당하는 픽업 정보가 없습니다.", "다시 확인해 주세요."),
     PICKUP_ALREADY_END(HttpStatus.BAD_REQUEST, "이미 종료된 픽업입니다.", "다시 확인해주세요."),
     IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 문제가 발생했습니다.", "다시 요청해주세요."),

--- a/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/repository/DriverRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -50,4 +51,21 @@ public class DriverRepository {
                 .setParameter("driverId", driverId)
                 .getResultList();
     }
+
+    public List<Object[]> findRemainingPickUpInfo(Long driverId) {
+        String query = "SELECT pui, pu.reservedTime " +
+                "FROM PickUpInfo pui " +
+                "JOIN PickUp pu ON pui.id = pu.pickUpInfo.id " +
+                "WHERE pui.driver.id = :driverId " +
+                "AND FUNCTION('DATE', pu.reservedTime) = :currentDate " +
+                "AND pu.endTime IS NULL " +
+                "AND pu.reservedTime > :oneHourBeforeNow";
+
+        return em.createQuery(query, Object[].class)
+                .setParameter("driverId", driverId)
+                .setParameter("currentDate", LocalDate.now())
+                .setParameter("oneHourBeforeNow", LocalDateTime.now().minusHours(1))
+                .getResultList();
+    }
+
 }

--- a/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
@@ -22,6 +22,7 @@ import ifive.idrop.entity.PickUpInfo;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static ifive.idrop.util.ScheduleUtils.*;
 
@@ -124,16 +125,17 @@ public class DriverService {
 
     @Transactional(readOnly = true)
     public List<DriverTodayRemainingPickUpResponse> getTodayRemainingPickUpList(Long driverId) {
-        List<DriverTodayRemainingPickUpResponse> response = new ArrayList<>();
-
         List<Object[]> remainingPickUpInfo = driverRepository.findRemainingPickUpInfo(driverId);
-        for (Object[] o : remainingPickUpInfo) {
-            PickUpInfo po = (PickUpInfo) o[0];
-            LocalDateTime reservedTime = (LocalDateTime) o[1];
-            response.add(DriverTodayRemainingPickUpResponse.of(po, reservedTime));
-        }
-        return response;
+
+        return remainingPickUpInfo.stream()
+                .map(o -> {
+                    PickUpInfo po = (PickUpInfo) o[0];
+                    LocalDateTime reservedTime = (LocalDateTime) o[1];
+                    return DriverTodayRemainingPickUpResponse.of(po, reservedTime);
+                })
+                .collect(Collectors.toList());
     }
+
 
     private void createPickUp(LocalDateTime localDateTime, PickUpInfo pickUpInfo) {
         PickUp pickUp = PickUp.builder()

--- a/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
@@ -122,8 +122,17 @@ public class DriverService {
         //TODO Alarm to Parent
     }
 
-    public BaseResponse<List<CurrentPickUpResponse>> getTodayRemainingPickUpList(Long driverId) {
-        //TODO 기사의 오늘 남은 픽업 업무 조회
+    @Transactional(readOnly = true)
+    public List<DriverTodayRemainingPickUpResponse> getTodayRemainingPickUpList(Long driverId) {
+        List<DriverTodayRemainingPickUpResponse> response = new ArrayList<>();
+
+        List<Object[]> remainingPickUpInfo = driverRepository.findRemainingPickUpInfo(driverId);
+        for (Object[] o : remainingPickUpInfo) {
+            PickUpInfo po = (PickUpInfo) o[0];
+            LocalDateTime reservedTime = (LocalDateTime) o[1];
+            response.add(DriverTodayRemainingPickUpResponse.of(po, reservedTime));
+        }
+        return response;
     }
 
     private void createPickUp(LocalDateTime localDateTime, PickUpInfo pickUpInfo) {

--- a/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
+++ b/BE/iDrop/src/main/java/ifive/idrop/service/DriverService.java
@@ -122,6 +122,10 @@ public class DriverService {
         //TODO Alarm to Parent
     }
 
+    public BaseResponse<List<CurrentPickUpResponse>> getTodayRemainingPickUpList(Long driverId) {
+        //TODO 기사의 오늘 남은 픽업 업무 조회
+    }
+
     private void createPickUp(LocalDateTime localDateTime, PickUpInfo pickUpInfo) {
         PickUp pickUp = PickUp.builder()
                 .reservedTime(localDateTime)


### PR DESCRIPTION
## 구현내용
기사가 `픽업시작` 버튼 클릭 시, 오늘 남은 픽업 업무를 조회해줍니다.
(현재시각-1시간) 이후에 reservedTime인 픽업들이 조회됩니다.
단, endImage가 존재하는 픽업은 이미 종료된 것으로 판단하여 조회되지 않습니다.

## 코드 간단 설명
### `DriverController`의 `getRemainingPickUpList` 메서드
```java
@GetMapping("/pickup/today/remaining")
public BaseResponse<List<DriverTodayRemainingPickUpResponse>> getRemainingPickUpList(@Login Driver driver) {
    List<DriverTodayRemainingPickUpResponse> pickUpList = driverService.getTodayRemainingPickUpList(driver.getId());
    if(pickUpList.size()==0)
        throw new CommonException(ErrorCode.PICKUP_NOT_FOUND);
    return BaseResponse.of("Data Successfully Proceed", pickUpList);
}
```
해당하는 픽업이 없으면 500대 에러를 내려달라는 프론트 팀원의 부탁이 있어 size가 0일 때 500대 에러를 메시지와 함께 내려주도록 했습니다.
다른 분들의 코드를 많이 참고하여 코드를 작성하였습니다.
주로 controller에서는 바로 service를 호출하여 return해줌으로써 한줄로 코드를 끝냈는데, 깔끔해서 보기가 좋긴하나 이 api가 어떤 응답들을 반환할 수 있는지 알기 어려울 수도 있을 것 같습니다. 그래서 기존 코드를 크게 해치지 않는 선에서, 응답되는 에러도 눈에 보이도록 코드를 작성해보았습니다. 후에 리펙토링 진행한다면 이런 모양은 어떨지 의견이 궁금합니다.

## 코드리뷰 후 변경사항
해당하는 픽업이 없으면 500대 에러 -> 그냥 빈 리스트를 리턴해주기로 함